### PR TITLE
Fix an issue happening with stat/lstat

### DIFF
--- a/src/NativeWrapper.php
+++ b/src/NativeWrapper.php
@@ -164,15 +164,22 @@ class NativeWrapper
 
     public function url_stat(string $path, int $flags): mixed
     {
+        if ($flags & STREAM_URL_STAT_QUIET) {
+            set_error_handler(function () {
+                return true;
+            });
+        }
+
         try {
             $func = $flags & STREAM_URL_STAT_LINK ? 'lstat' : 'stat';
-
-            return $flags & STREAM_URL_STAT_QUIET
-                ? @$this->native($func, $path)
-                : $this->native($func, $path);
+            return $this->native($func, $path);
         } catch (\RuntimeException $e) {
             // SplFileInfo::isFile throws exception
             return false;
+        } finally {
+            if ($flags & STREAM_URL_STAT_QUIET) {
+                restore_error_handler();
+            }
         }
     }
 


### PR DESCRIPTION
When updating dependencies in my project, I ran into an issue where I would get warnings from `stat`

<img width="1448" alt="image" src="https://github.com/user-attachments/assets/ff8f820e-d04d-40de-9883-4522df3bacc6" />

Long story short, I tracked it down to bypass-readonly, which I was doing to be able to mock readonly classes in my tests.

Here you can see some discussion, and a lead: https://github.com/pestphp/pest/issues/851#issuecomment-2043278517

Which lead me to this thread: https://github.com/dg/bypass-finals/pull/54

and this solution: https://github.com/dg/bypass-finals/commit/8616a09193aa7ffa24c78849a6f61b380bbf7b46

Which I have implemented in the PR.

Would love to get this merged in so I don't have to maintain my own fork/fix. 😄 